### PR TITLE
Fix Next.js env fallback

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,5 +1,5 @@
-function getEnv(key: string): string {
-  const value = process.env[key]
+function getEnv(key: string, fallback?: string): string {
+  const value = process.env[key] ?? fallback
   if (!value) {
     throw new Error(`Missing env variable: ${key}`)
   }
@@ -9,7 +9,14 @@ function getEnv(key: string): string {
 export const env = {
   NEXT_PUBLIC_SUPABASE_URL: getEnv('NEXT_PUBLIC_SUPABASE_URL'),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: getEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
-  NEXT_PUBLIC_APP_URL: getEnv('NEXT_PUBLIC_APP_URL'),
+  NEXT_PUBLIC_APP_URL: getEnv(
+    'NEXT_PUBLIC_APP_URL',
+    process.env.NEXT_PUBLIC_VERCEL_URL
+      ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+      : process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : 'http://localhost:3000'
+  ),
   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: getEnv('NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY'),
   STRIPE_SECRET_KEY: getEnv('STRIPE_SECRET_KEY'),
   STRIPE_WEBHOOK_SECRET: getEnv('STRIPE_WEBHOOK_SECRET'),


### PR DESCRIPTION
## Summary
- ensure `NEXT_PUBLIC_APP_URL` falls back to Vercel provided values

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_6841a78945cc8329ac77d1fef879a83f