### PR TITLE
Fix pdf utilities typescript errors

### DIFF
--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { pdf, Document, Page } from '@react-pdf/renderer'
+import { pdf } from '@react-pdf/renderer'
 import { InvoicePDF } from '@/components/InvoicePDF'
 import { Invoice, InvoiceItem } from '@/lib/types'
 import { generateInvoiceNumber } from '@/lib/invoiceUtils'


### PR DESCRIPTION
Remove unused `Document` and `Page` imports from `pdfUtils.ts` to resolve ESLint warnings.

---

[Open in Web](https://cursor.com/agents?id=bc-c6cebf9b-b7ab-4c3b-92d4-bc1b69ebfa61) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c6cebf9b-b7ab-4c3b-92d4-bc1b69ebfa61) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)